### PR TITLE
Update reference to google-cloud-spanner gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "gcloud-ruby"]
-	path = vendor/gcloud-ruby
-	url = https://github.com/GoogleCloudPlatform/google-cloud-ruby

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in activerecord-spanner-adapter.gemspec
 gemspec
 
-gem 'google-cloud-spanner', path: 'vendor/gcloud-ruby/google-cloud-spanner'
 gem 'pry'
 gem 'pry-byebug'

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'activerecord', "~> 5.0"
-  spec.add_dependency 'google-cloud-spanner'
+  spec.add_dependency 'google-cloud-spanner', "~> 0.23"
   spec.add_dependency 'google-gax', '~> 0.8'
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
It is now available in rubygems.org